### PR TITLE
Enable to run from any filesystem location

### DIFF
--- a/arcasHLA
+++ b/arcasHLA
@@ -48,25 +48,27 @@ fi
 #   Tools
 #-----------------------------------------------------------------------------
 
+ARCASHLA_ROOT_DIR=$(realpath $(dirname $0))
+
 if [ "$1" == "extract" ]; then
 
-    python3 ./scripts/extract.py ${@:2}
+    python3 ${ARCASHLA_ROOT_DIR}/scripts/extract.py ${@:2}
 
 elif [ "$1" == "genotype" ]; then
 
-    python3 ./scripts/genotype.py ${@:2}
+    python3 ${ARCASHLA_ROOT_DIR}/scripts/genotype.py ${@:2}
 
 elif [ "$1" == "merge" ]; then
 
-    python3 ./scripts/merge.py ${@:2}
+    python3 ${ARCASHLA_ROOT_DIR}/scripts/merge.py ${@:2}
 
 elif [ "$1" == "reference" ]; then
 
-    python3 ./scripts/reference.py ${@:2}
+    python3 ${ARCASHLA_ROOT_DIR}/scripts/reference.py ${@:2}
 
 elif [ "$1" == "partial" ]; then
 
-    python3 ./scripts/partial.py ${@:2}
+    python3 ${ARCASHLA_ROOT_DIR}/scripts/partial.py ${@:2}
     
 #-----------------------------------------------------------------------------
 #   Usage

--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -219,6 +219,8 @@ if __name__ == '__main__':
     
     sample = os.path.basename(args.bam).split('.')[0]
     
+    datDir = os.path.dirname(os.path.realpath(__file__)) + '/../dat/'
+    
     if args.log:
         log_file = args.log
     else:
@@ -249,7 +251,7 @@ if __name__ == '__main__':
              .format( 'paired' if args.paired else 'single'))
     hline()
     
-    with open('dat/info/decoys_alts.p', 'rb') as file:
+    with open(datDir + '/info/decoys_alts.p', 'rb') as file:
         alts = pickle.load(file)
     
     extract_reads(args.bam,

--- a/scripts/genotype.py
+++ b/scripts/genotype.py
@@ -51,10 +51,12 @@ __date__        = 'November 2018'
 #   Paths and filenames
 #-------------------------------------------------------------------------------
 
-hla_p      = 'dat/ref/hla.p'
-hla_idx    = 'dat/ref/hla.idx'
-hla_freq   = 'dat/info/hla_freq.tsv'
-parameters = 'dat/info/parameters.p'
+rootDir = os.path.dirname(os.path.realpath(__file__)) + '/../'
+
+hla_p      = rootDir + 'dat/ref/hla.p'
+hla_idx    = rootDir + 'dat/ref/hla.idx'
+hla_freq   = rootDir + 'dat/info/hla_freq.tsv'
+parameters = rootDir + 'dat/info/parameters.p'
 
 #-----------------------------------------------------------------------------
 # Process and align FASTQ input
@@ -810,7 +812,7 @@ if __name__ == '__main__':
     prior = prior.set_index('allele').to_dict('index')
        
     # checks if HLA reference exists
-    check_path('dat/ref')
+    check_path(rootDir + 'dat/ref')
     check_ref()
     
     # loads reference information

--- a/scripts/partial.py
+++ b/scripts/partial.py
@@ -50,9 +50,11 @@ __date__        = 'November 2018'
 #   Paths and filenames
 #-------------------------------------------------------------------------------
 
-partial_p       = 'dat/ref/hla_partial.p'
-partial_idx     = 'dat/ref/hla_partial.idx'
-hla_freq        = 'dat/info/hla_freq.tsv'
+rootDir = os.path.dirname(os.path.realpath(__file__)) + '/../'
+
+partial_p       = rootDir + 'dat/ref/hla_partial.p'
+partial_idx     = rootDir + 'dat/ref/hla_partial.idx'
+hla_freq        = rootDir + 'dat/info/hla_freq.tsv'
 
 #-------------------------------------------------------------------------------
 # Process transcript assembly output
@@ -347,7 +349,7 @@ def arg_check_threshold(parser, arg):
 
 if __name__ == '__main__':
     
-    with open('dat/info/parameters.p', 'rb') as file:
+    with open(rootDir + 'dat/info/parameters.p', 'rb') as file:
         genes, populations, databases = pickle.load(file)
     
     parser = argparse.ArgumentParser(prog='arcasHLA partial',

--- a/scripts/reference.py
+++ b/scripts/reference.py
@@ -54,7 +54,7 @@ __date__        = 'November 2018'
 rootDir = dirname(realpath(__file__)) + '/../'
 
 IMGTHLA         = rootDir + 'dat/IMGTHLA/'
-IMGTHLA_git     = rootDir + 'https://github.com/ANHIG/IMGTHLA.git'
+IMGTHLA_git     = 'https://github.com/ANHIG/IMGTHLA.git'
 hla_dat         = rootDir + 'dat/IMGTHLA/hla.dat'
 hla_fa          = rootDir + 'dat/ref/hla.fasta'
 partial_fa      = rootDir + 'dat/ref/hla_partial.fasta'

--- a/scripts/reference.py
+++ b/scripts/reference.py
@@ -30,7 +30,7 @@ import argparse
 import logging as log
 
 from argparse import RawTextHelpFormatter
-from os.path import isfile, isdir
+from os.path import isfile, isdir, dirname, realpath
 from subprocess import PIPE, run
 
 from textwrap import wrap
@@ -51,16 +51,18 @@ __date__        = 'November 2018'
 #   Paths and filenames
 #-------------------------------------------------------------------------------
 
-IMGTHLA         = 'dat/IMGTHLA/'
-IMGTHLA_git     = 'https://github.com/ANHIG/IMGTHLA.git'
-hla_dat         = 'dat/IMGTHLA/hla.dat'
-hla_fa          = 'dat/ref/hla.fasta'
-partial_fa      = 'dat/ref/hla_partial.fasta'
-hla_p           = 'dat/ref/hla.p'
-partial_p       = 'dat/ref/hla_partial.p'
-hla_idx         = 'dat/ref/hla.idx'
-partial_idx     = 'dat/ref/hla_partial.idx'
-parameters      = 'dat/info/parameters.p'
+rootDir = dirname(realpath(__file__)) + '/../'
+
+IMGTHLA         = rootDir + 'dat/IMGTHLA/'
+IMGTHLA_git     = rootDir + 'https://github.com/ANHIG/IMGTHLA.git'
+hla_dat         = rootDir + 'dat/IMGTHLA/hla.dat'
+hla_fa          = rootDir + 'dat/ref/hla.fasta'
+partial_fa      = rootDir + 'dat/ref/hla_partial.fasta'
+hla_p           = rootDir + 'dat/ref/hla.p'
+partial_p       = rootDir + 'dat/ref/hla_partial.p'
+hla_idx         = rootDir + 'dat/ref/hla.idx'
+partial_idx     = rootDir + 'dat/ref/hla_partial.idx'
+parameters      = rootDir + 'dat/info/parameters.p'
 
 #-------------------------------------------------------------------------------
 #   Fetch and process IMGTHLA database
@@ -459,7 +461,7 @@ if __name__ == '__main__':
     log.info('')
     hline()
     
-    check_path('dat/ref')
+    check_path(rootDir + 'dat/ref')
 
     if args.update:
         log.info('[reference] Updating HLA reference')


### PR DESCRIPTION
This is useful if the tool is
installed globally on the system e.g. /usr/local/arcasHLA
The circumvent the requirement a user has first to change into the
arcasHLA directory.