### PR TITLE
add --avg and --std arguments and defaults for kallisto single-end reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 clean_ref
 *.log
 __pycache__/
+arcashla_latest.sif

--- a/scripts/align.py
+++ b/scripts/align.py
@@ -56,43 +56,8 @@ rootDir = os.path.dirname(os.path.realpath(__file__)) + '/../'
 # Process and align FASTQ input
 #-----------------------------------------------------------------------------
 
-def analyze_reads(fqs, paired, reads_file):
-    '''Analyzes read length for single-end sampled, required by Kallisto.'''
-    
-    awk = "| awk '{if(NR%4==2) print length($1)}'"
-    
-    if fqs[0].endswith('.gz'):
-        cat = 'zcat'
-    else:
-        cat = 'cat'
-    
-    log.info('[alignment] Analyzing read length')
-    if paired:
-        fq1, fq2 = fqs
-        run_command([cat, '<', fq1, awk, '>' , reads_file])
-        run_command([cat, '<', fq2, awk, '>>', reads_file])
-        
-    else:
-        fq = fqs[0]
-        run_command([cat, '<', fq, awk, '>', reads_file])
-        
-    read_lengths = np.genfromtxt(reads_file)
-    
-    if len(read_lengths) == 0:
-        sys.exit('[genotype] Error: FASTQ files are empty; check arcasHLA extract for issues.')
-    
-    num = len(read_lengths)
-    avg = round(np.mean(read_lengths), 6)
-    std = round(np.std(read_lengths), 6)
-    
-    return num, avg, std
-
-def pseudoalign(fqs, sample, paired, reference, outdir, temp, threads):
+def pseudoalign(fqs, sample, paired, reference, outdir, temp, threads, avg, std):
     '''Calls Kallisto to pseudoalign reads.'''
-    
-    # Get read length stats
-    reads_file = ''.join([temp, sample, '.reads.txt'])
-    num, avg, std = analyze_reads(fqs, paired, reads_file)
     
     # Kallisto fails if std used for single-end is 0
     std = max(std, 1e-6)
@@ -106,8 +71,8 @@ def pseudoalign(fqs, sample, paired, reference, outdir, temp, threads):
         command.extend(['--single -l', str(avg), '-s', str(std), fq])
         
     run_command(command, '[alignment] Pseudoaligning with Kallisto: ')
+
            
-    return num, avg, std
 
 #-----------------------------------------------------------------------------
 # Process transcript assembly output
@@ -227,9 +192,9 @@ def get_count_stats(eq_idx, gene_length):
 
 def alignment_summary(align_stats, partial = False):
     '''Prints alignment summary to log.'''
-    count_unique, count_multi, total, _, _ = align_stats
-    log.info('[alignment] Processed {:.0f} reads, {:.0f} pseudoaligned '
-             .format(total, count_unique + count_multi)+
+    count_unique, count_multi, _, _ = align_stats
+    log.info('[alignment] Pseudoaligned {:.0f} reads '
+             .format(count_unique + count_multi)+
              'to HLA reference')
               
     log.info('[alignment] {:.0f} reads mapped to a single HLA gene'
@@ -247,20 +212,22 @@ def gene_summary(gene_stats):
         log.info('\t\tHLA-{: <6}    {: >8.2f}%    {: >10.0f}    {: >7.0f}'
                  .format(g, a*100, c, e))
 
-def get_alignment(fqs, sample, reference, reference_info, outdir, temp, threads, partial = False):
+def get_alignment(fqs, sample, reference, reference_info, outdir, temp, threads, partial = False, avg = 200, std = 20):
     '''Runs pseudoalignment and processes output.'''
     paired = True if len(fqs) == 2 else False
         
     count_file = ''.join([temp, 'pseudoalignments.tsv'])
     eq_file = ''.join([temp, 'pseudoalignments.ec'])
 
-    total, avg, std = pseudoalign(fqs,
-                                 sample,
-                                 paired,
-                                 reference,
-                                 outdir, 
-                                 temp,
-                                 threads)
+    pseudoalign(fqs,
+                sample,
+                paired,
+                reference,
+                outdir,
+                temp,
+                threads,
+                avg,
+                std)
     
     # Process partial genotyping pseudoalignment
     if partial:
@@ -275,7 +242,7 @@ def get_alignment(fqs, sample, reference, reference_info, outdir, temp, threads,
                                                lengths,
                                                exon_idx,
                                                exon_combos)
-        align_stats.extend([total, avg, std])
+        align_stats.extend([avg, std])
         
         alignment_summary(align_stats, True)
         
@@ -295,7 +262,7 @@ def get_alignment(fqs, sample, reference, reference_info, outdir, temp, threads,
                                                         allele_idx, 
                                                         lengths)
         
-        align_stats.extend([total, avg, std])
+        align_stats.extend([avg, std])
         
         alignment_summary(align_stats)
         

--- a/scripts/align.py
+++ b/scripts/align.py
@@ -60,13 +60,11 @@ def pseudoalign(fqs, sample, paired, reference, outdir, temp, threads, avg, std)
     '''Calls Kallisto to pseudoalign reads.'''
 
     command = ['kallisto pseudo -i', reference, '-t', threads, '-o', temp]
-        
-    if paired:
-        command.extend([fqs[0], fqs[1]])
-    else:
-        fq = fqs[0]
-        command.extend(['--single -l', str(avg), '-s', str(std), fq])
-        
+
+    if not paired:
+        command.extend(['--single -l', str(avg), '-s', str(std)])
+
+    command.extend(fqs)
     run_command(command, '[alignment] Pseudoaligning with Kallisto: ')
 
            

--- a/scripts/align.py
+++ b/scripts/align.py
@@ -43,8 +43,8 @@ from itertools import combinations
 from reference import check_ref, get_exon_combinations
 from arcas_utilities import *
 
-__version__     = '0.2.0'
-__date__        = '2019-06-26'
+__version__     = '0.3.0'
+__date__        = '2020-09-28'
 
 #-------------------------------------------------------------------------------
 #   Paths and filenames
@@ -58,9 +58,6 @@ rootDir = os.path.dirname(os.path.realpath(__file__)) + '/../'
 
 def pseudoalign(fqs, sample, paired, reference, outdir, temp, threads, avg, std):
     '''Calls Kallisto to pseudoalign reads.'''
-    
-    # Kallisto fails if std used for single-end is 0
-    std = max(std, 1e-6)
 
     command = ['kallisto pseudo -i', reference, '-t', threads, '-o', temp]
         
@@ -212,9 +209,9 @@ def gene_summary(gene_stats):
         log.info('\t\tHLA-{: <6}    {: >8.2f}%    {: >10.0f}    {: >7.0f}'
                  .format(g, a*100, c, e))
 
-def get_alignment(fqs, sample, reference, reference_info, outdir, temp, threads, partial = False, avg = 200, std = 20):
+def get_alignment(fqs, sample, reference, reference_info, outdir, temp, threads, single, partial = False, avg = 200, std = 20):
     '''Runs pseudoalignment and processes output.'''
-    paired = True if len(fqs) == 2 else False
+    paired = not single
         
     count_file = ''.join([temp, 'pseudoalignments.tsv'])
     eq_file = ''.join([temp, 'pseudoalignments.ec'])

--- a/scripts/genotype.py
+++ b/scripts/genotype.py
@@ -44,8 +44,8 @@ from reference import check_ref
 from arcas_utilities import *
 from align import *
 
-__version__     = '0.2.0'
-__date__        = '2019-06-26'
+__version__     = '0.3.0'
+__date__        = '2020-09-28'
 
 #-------------------------------------------------------------------------------
 #   Paths and filenames
@@ -630,6 +630,23 @@ if __name__ == '__main__':
                         action = 'count',
                         default=False)
 
+    parser.add_argument('-l',
+                        '--avg', 
+                        help='Estimated average fragment length ' +
+                                'for single-end reads\n  default: 200\n\n',
+                        default=200)
+
+    parser.add_argument('-s',
+                        '--std', 
+                        help='Estimated standard deviation of fragment length ' +
+                             'for single-end reads\n  default: 20\n\n',
+                        default=20)
+
+    parser.add_argument('--single',
+                        type=bool,
+                        help='Are reads single-end?\n\n')
+
+
     args = parser.parse_args()
     
     if len(args.file) == 0:
@@ -686,7 +703,7 @@ if __name__ == '__main__':
         alignment_info = load_alignment(args.file[0], commithash)
     else:
         alignment_info = get_alignment(args.file, sample, hla_idx,
-                                      reference_info, outdir, temp, args.threads)
+                                      reference_info, outdir, temp, args.threads, args.single, avg=args.avg, std=args.std)
         
     commithash, eq_idx, allele_eq, paired, align_stats, gene_stats = alignment_info
 

--- a/scripts/partial.py
+++ b/scripts/partial.py
@@ -426,6 +426,18 @@ if __name__ == '__main__':
                         '--verbose', 
                         action = 'count',
                         default=False)
+
+    parser.add_argument('-l',
+                        '--avg', 
+                        help='Estimated average fragment length ' +
+                             'for single-end reads\n  default: 200\n\n',
+                        default=200)
+
+    parser.add_argument('-s',
+                        '--std', 
+                        help='Estimated standard deviation of fragment length ' +
+                             'for single-end reads\n  default: 20\n\n',
+                        default=20)
     args = parser.parse_args()
     
     if len(args.file) == 0:
@@ -482,7 +494,7 @@ if __name__ == '__main__':
     else:
         alignment_info = get_alignment(args.file, sample, partial_idx,
                                        reference_info, outdir, temp, 
-                                       args.threads, True)
+                                       args.threads, True, args.avg, args.std)
     commithash, eq_idx, _, paired, align_stats, _ = alignment_info
      
     # Load alleles from arcasHLA genotype

--- a/scripts/partial.py
+++ b/scripts/partial.py
@@ -43,8 +43,8 @@ from arcas_utilities import *
 from align import *
 from genotype import expectation_maximization
 
-__version__     = '0.2.0'
-__date__        = '2019-06-26'
+__version__     = '0.3.0'
+__date__        = '2020-09-28'
 
 #-------------------------------------------------------------------------------
 #   Paths and filenames
@@ -438,6 +438,11 @@ if __name__ == '__main__':
                         help='Estimated standard deviation of fragment length ' +
                              'for single-end reads\n  default: 20\n\n',
                         default=20)
+
+    parser.add_argument('--single',
+                        type=bool,
+                        help='Are reads single-end?\n\n')
+
     args = parser.parse_args()
     
     if len(args.file) == 0:
@@ -494,7 +499,7 @@ if __name__ == '__main__':
     else:
         alignment_info = get_alignment(args.file, sample, partial_idx,
                                        reference_info, outdir, temp, 
-                                       args.threads, True, args.avg, args.std)
+                                       args.threads, True, args.single, args.avg, args.std)
     commithash, eq_idx, _, paired, align_stats, _ = alignment_info
      
     # Load alleles from arcasHLA genotype


### PR DESCRIPTION
Fixes #43

Previous versions of arcasHLA used the read length and standard deviation
which is the incorrect behaviour. It should use the fragment length and
standard deviation which must be determined experimentally.

The kallisto manual states: "Typical Illumina libraries produce fragment
lengths ranging from 180–200 bp but it’s best to determine this from a
library quantification with an instrument such as an Agilent Bioanalyzer."
and gives an example with "-l 200 -s 20". These values are thus chosen
as sane defaults in the absense of experimental info.

This commit should also substantially improve the performance of the slow
and memory hungry `analyze_reads`.