### PR TITLE
Update samtools, bedtools, and kallisto versions

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -2,9 +2,9 @@
 FROM ubuntu:18.04
 
 # set the environment variables
-ENV kallisto_version 0.44.0
-ENV samtools_version 1.9
-ENV bedtools_version 2.29.2
+ENV kallisto_version 0.46.2
+ENV samtools_version 1.11
+ENV bedtools_version 2.30.0
 ENV biopython_version 1.77
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8


### PR DESCRIPTION
Hello. I’m a master’s student and investigating whether updates from one project are useful for another project.
In this pull request, I am updating samtools from 1.9 to 1.11, bedtools from 2.29.2 to 2.30.0, and kallisto from 0.44.0 to 0.46.2.  Since these updates are being done in https://github.com/broadinstitute/gtex-pipeline/commit/5224f82077956b25e4d5c18bbe13770fca21f95b, I’m wondering if this project can update the libraries as well.